### PR TITLE
sudo not required for curl, hangs on some systems

### DIFF
--- a/lib/yum.js
+++ b/lib/yum.js
@@ -21,8 +21,6 @@ Yum.prototype.downloadEpel = function(cb) {
   var _this = this,
     command = 'curl -XGET ' + this.epelDownloadUrl + ' > epel-release-6-8.noarch.rpm';
 
-  if (this.sudo) command = 'sudo ' + command;
-
   return new Promise(function(resolve, reject) {
     _this.util.exec(command, {cwd: '/tmp'}, function() {
       resolve();


### PR DESCRIPTION
On a RHEL6 system, doing a `sudo curl ... > /tmp/whatever` hangs, not
sure how common this is, I haven't seen it before. The `sudo` isn't
required anyway so can be removed.
